### PR TITLE
Get rid of implicit type conversion

### DIFF
--- a/app/controllers/time_loggers_controller.rb
+++ b/app/controllers/time_loggers_controller.rb
@@ -8,8 +8,8 @@ class TimeLoggersController < ApplicationController
             @paused_time_loggers = TimeLogger.where(paused: 1)
         else
             @user_time_loggers = TimeLogger.where(user_id: User.current.id)
-            @time_loggers = TimeLogger.where('paused = 0 and user_id != ?', User.current.id)
-            @paused_time_loggers = TimeLogger.where('paused = 1 and user_id != ?', User.current.id)
+            @time_loggers = TimeLogger.where('paused = false and user_id != ?', User.current.id)
+            @paused_time_loggers = TimeLogger.where('paused = true and user_id != ?', User.current.id)
         end
     end
 


### PR DESCRIPTION
We were experiencing error with invalid type comparison on the following software: 
- ruby 2.3.6
- psql 9.5.10
- Redmine 3.4.3

`ActionView::Template::Error (PG::UndefinedFunction: ERROR:  operator does not exist: boolean = integer
LINE 1: SELECT COUNT(*) FROM "time_loggers" WHERE (paused = 0 and us...
                                                          ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT COUNT(*) FROM "time_loggers" WHERE (paused = 0 and user_id != 115)):
    52: <% if User.current.allowed_to?(:view_others_time_loggers, nil, :global => true) %>
    53:     <div id="all-time-loggers-list">
    54:         <h3><%= l(:time_logger_label_other_time_loggers) %></h3>
    55:         <% if !@time_loggers.nil? and !@time_loggers.empty? %>
    56:             <div class="autoscroll">
    57:                 <table class="list">
    58:                     <thead>
  plugins/time_logger/app/views/time_loggers/index.html.erb:55:in`